### PR TITLE
Return 404 via handle_response too

### DIFF
--- a/lib/Plack/App/Path/Router/Custom.pm
+++ b/lib/Plack/App/Path/Router/Custom.pm
@@ -194,7 +194,10 @@ sub call {
         return $self->handle_response( $res, $req );
     }
 
-    return [ 404, [ 'Content-Type' => 'text/html' ], [ 'Not Found' ] ];
+    return $self->handle_response(
+      [ 404, [ 'Content-Type' => 'text/html' ], [ 'Not Found' ] ] ,
+      $req ,
+    );
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/t/custom_response.t
+++ b/t/custom_response.t
@@ -1,0 +1,53 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use Path::Router;
+use Plack::Test;
+use Scalar::Util qw/ blessed /;
+
+use Plack::App::Path::Router::Custom;
+
+my $router = Path::Router->new;
+$router->add_route('/bar' => target => sub { [ 200, [], ['BAR']] } );
+
+my $app = Plack::App::Path::Router::Custom->new(
+    router => $router,
+    handle_response => sub {
+        my ($res, $req) = @_;
+        if (!ref($res)) {
+            return [ 200, [], [$res] ];
+        }
+        elsif (blessed($res) && $res->can('finalize')) {
+            return $res->finalize;
+        }
+        elsif ( $res->[0] eq 404 ) {
+            $res->[2] = ['Overriden 404 message'];
+            return $res;
+        }
+        else {
+            return $res;
+        }
+    },
+);
+
+test_psgi
+      app    => $app,
+      client => sub {
+          my $cb = shift;
+          {
+              my $req = HTTP::Request->new(GET => "http://localhost/bar");
+              my $res = $cb->($req);
+              is($res->code, 200, '... got the expected match');
+          }
+          {
+              my $req = HTTP::Request->new(GET => "http://localhost/foo");
+              my $res = $cb->($req);
+              is($res->code, 404, '... got the expected fail');
+              is($res->content, 'Overriden 404 message', '... got the expected message');
+          }
+      };
+
+done_testing;


### PR DESCRIPTION
With the way call() was previously implemented, you couldn't change the
404 response. Returning it via handle_response means you have that
option.
