### PR TITLE
Fix extraction of zero-valued components [#4]

### DIFF
--- a/Changes
+++ b/Changes
@@ -6,8 +6,11 @@ Revision history for Plack-App-Path-Router
       Plack::App::Path::Router::Custom, to provide more granular
       control over response handling. (John Anderson)
 
+    - Fix bug in component value extraction where a zero valued
+      compotent would match but not extract properly. (John Anderson)
+
 0.06  2014-09-01
-    - return 404 via handle_response too 
+    - return 404 via handle_response too
       (thanks to John "genehack" Anderson for this fix)
 
 0.05  2012-04-20

--- a/lib/Plack/App/Path/Router/Custom.pm
+++ b/lib/Plack/App/Path/Router/Custom.pm
@@ -199,7 +199,8 @@ sub call {
         foreach my $component ( @{ $route->components } ) {
             my $name = $route->get_component_name( $component );
             next unless $name;
-            if (my $value = $mapping->{ $name }) {
+            my $value = $mapping->{ $name };
+            if (defined $value) {
                 push @args => $value;
                 $env->{ ('plack.router.match.args.' . $name) } = $value;
             }

--- a/t/basic_custom.t
+++ b/t/basic_custom.t
@@ -105,6 +105,17 @@ test_psgi
               is($res->header('X-New-Request'), $res->header('X-Res-Req'));
           }
           {
+              my $req = HTTP::Request->new(GET => "http://localhost/bar/0", [ "Authorization" => "Basic YWRtaW46czNjcjN0" ]);
+              my $res = $cb->($req);
+              is($res->code, 200, '... got the expected auth fail');
+              is($res->content, 'BAR/0', '... got the right value for /bar/0');
+              like($res->header('X-New-Request'), qr/^HASH/);
+              is($res->header('X-Number-Of-Matches'), 1);
+              like($res->header('X-Res'), qr/^ARRAY/);
+              like($res->header('X-Res-Req'), qr/^HASH/);
+              is($res->header('X-New-Request'), $res->header('X-Res-Req'));
+          }
+          {
               my $req = HTTP::Request->new(GET => "http://localhost/bar/baz", [ "Authorization" => "Basic fake" ]);
               my $res = $cb->($req);
               is($res->code, 401, '... got the expected auth fail');


### PR DESCRIPTION
This fixes the problem, and all the rest of the tests pass.

Running `prove` (note: without the `-l`', so testing against the previous, installed version) I get a failure in `t/basic_custom.t` that looks like this:

>t/basic_custom.t .............. 1/? Use of uninitialized value $baz in uc at t/basic_custom.t line 21.
>
>\#   Failed test '... got the right value for /bar/0'
>\#   at t/basic_custom.t line 111.
>\#          got: 'BAR/'
>\#     expected: 'BAR/0'
>
>\#   Failed test at t/basic_custom.t line 113.
>\#          got: '0'
>\#     expected: '1'
>\# Looks like you failed 2 tests of 46.
